### PR TITLE
Fix vercel build error: delete navigator webdriver

### DIFF
--- a/app/api/public/html/route.ts
+++ b/app/api/public/html/route.ts
@@ -95,8 +95,14 @@ export async function POST(request: NextRequest) {
       // Remove webdriver property completely
       Object.defineProperty(navigator, 'webdriver', {
         get: () => undefined,
+        configurable: true,
       });
-      try { delete (navigator as any).webdriver; } catch (_) { // Ignore if property is read-only }
+      try { 
+        delete (navigator as unknown as Record<string, unknown>).webdriver; 
+      } catch (e) { 
+        // Ignore if property is read-only 
+        console.log('Could not delete webdriver property:', e);
+      }
 
       // Override plugins with realistic values
       Object.defineProperty(navigator, 'plugins', {
@@ -117,7 +123,14 @@ export async function POST(request: NextRequest) {
       const originalQuery = window.navigator.permissions.query;
       window.navigator.permissions.query = (parameters) => (
         parameters.name === 'notifications' ?
-          Promise.resolve({ state: Notification.permission }) :
+          Promise.resolve({ 
+            state: Notification.permission,
+            name: parameters.name,
+            onchange: null,
+            addEventListener: () => {},
+            removeEventListener: () => {},
+            dispatchEvent: () => false
+          } as PermissionStatus) :
           originalQuery(parameters)
       );
 
@@ -256,10 +269,10 @@ export async function POST(request: NextRequest) {
           await new Promise(resolve => setTimeout(resolve, 1000 + Math.random() * 2000));
           await page.mouse.click(Math.random() * 1000, Math.random() * 800);
           await new Promise(resolve => setTimeout(resolve, 500));
-          await page.mouse.wheel(0, Math.random() * 500);
+          await page.evaluate(() => window.scrollBy(0, Math.random() * 500));
           await new Promise(resolve => setTimeout(resolve, 1000));
-        } catch (_) {
-          console.log('Public HTML API: Human simulation failed:', e.message);
+        } catch (e) {
+          console.log('Public HTML API: Human simulation failed:', e instanceof Error ? e.message : String(e));
         }
         
         // Wait for Cloudflare to process
@@ -287,7 +300,7 @@ export async function POST(request: NextRequest) {
               { timeout: 15000 }
             ).catch(() => console.log('Public HTML API: Content change timeout')),
           ]);
-        } catch (_) {
+        } catch {
           console.log(`Public HTML API: Detection timeout on attempt ${attempts}`);
         }
         

--- a/app/api/public/url/route.ts
+++ b/app/api/public/url/route.ts
@@ -103,7 +103,12 @@ export async function POST(request: NextRequest) {
       Object.defineProperty(navigator, 'webdriver', {
         get: () => undefined,
       });
-      try { delete (navigator as any).webdriver; } catch (_) { // Ignore if property is read-only }
+      try { 
+        delete (navigator as unknown as Record<string, unknown>).webdriver; 
+      } catch (e) { 
+        // Ignore if property is read-only 
+        console.log('Could not delete webdriver property:', e);
+      }
 
       Object.defineProperty(navigator, 'plugins', {
         get: () => ({
@@ -207,7 +212,7 @@ export async function POST(request: NextRequest) {
           waitUntil: 'domcontentloaded', 
           timeout: 10000 
         }).catch(() => console.log('Public URL API: Navigation timeout'));
-      } catch (_) {
+      } catch {
         console.log(`Public URL API: Detection timeout on attempt ${attempts}`);
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7988,6 +7988,96 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.2.tgz",
+      "integrity": "sha512-8bGt577BXGSd4iqFygmzIfTYizHb0LGWqH+qgIF/2EDxS5JsSdERJKA8WgwDyNBZgTIIA4D8qUtoQHmxIIquoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.2.tgz",
+      "integrity": "sha512-2DjnmR6JHK4X+dgTXt5/sOCu/7yPtqpYt8s8hLkHFK3MGkka2snTv3yRMdHvuRtJVkPwCGsvBSwmoQCHatauFQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.2.tgz",
+      "integrity": "sha512-3j7SWDBS2Wov/L9q0mFJtEvQ5miIqfO4l7d2m9Mo06ddsgUK8gWfHGgbjdFlCp2Ek7MmMQZSxpGFqcC8zGh2AA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.2.tgz",
+      "integrity": "sha512-s6N8k8dF9YGc5T01UPQ08yxsK6fUow5gG1/axWc1HVVBYQBgOjca4oUZF7s4p+kwhkB1bDSGR8QznWrFZ/Rt5g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.2.tgz",
+      "integrity": "sha512-sMPyTvRcNKXseNQ/7qRfVRLa0VhR0esmQ29DD6pqvG71+JdVnESJaHPA8t7bc67KD5spP3+DOCNLhqlEI2ZgQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.2.tgz",
+      "integrity": "sha512-W5VvyZHnxG/2ukhZF/9Ikdra5fdNftxI6ybeVKYvBPDtyx7x4jPPSNduUkfH5fo3zG0JQ0bPxgy41af2JX5D4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes multiple TypeScript and ESLint errors to resolve Vercel deployment failures.

The build was failing due to issues such as attempting to delete a read-only `navigator.webdriver` property, syntax errors in catch blocks, unused variables, `PermissionStatus` interface mismatches, and incorrect `page.mouse.wheel` API usage.

---
<a href="https://cursor.com/background-agent?bcId=bc-cf976065-927c-4ba6-9608-ed43c36aed59">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cf976065-927c-4ba6-9608-ed43c36aed59">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

